### PR TITLE
Update Makefile line 378,add -std=c++11 in CXXFLAGS .

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ CXXFLAGS += -MMD -MP
 
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
-CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
+CXXFLAGS += -pthread -fPIC -std=c++11 $(COMMON_FLAGS) $(WARNINGS)
 NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized


### PR DESCRIPTION
fixed issue some error about stdc++ 11 in Ubuntu 14.04 #3
add -std=c++11 to CXXFLAGS in Makefile
